### PR TITLE
Added route to read user cookie on frontend

### DIFF
--- a/server/routers/userRouter.js
+++ b/server/routers/userRouter.js
@@ -12,11 +12,13 @@ router.get('/allQueries',
   return res.status(200).json(res.locals.allQueries) // Used with frontend
 });
 
-router.get('/test', 
+router.get('/cookie', 
   sessionController.verifySession, 
-  // userController.checkUser,
-  // userController.addUser,
   (req, res) => {
-  return res.status(200).send('reached the end of the test route');
+  let loggedIn = false;
+  if (res.locals.username !== undefined) {
+    loggedIn = true;
+  }
+  return res.status(200).send(loggedIn);
 })
 module.exports = router;


### PR DESCRIPTION
Cookie can now be read on the front end by making a GET request to /user/cookie. The server will send back a boolean. TRUE if the user is logged in, and FALSE if the user is not logged in.